### PR TITLE
Disallow more than one map to load at once

### DIFF
--- a/code/modules/random_map/random_map.dm
+++ b/code/modules/random_map/random_map.dm
@@ -139,7 +139,9 @@ var/global/list/map_count = list()
 	if(check_map_sanity())
 		cleanup()
 		if(auto_apply)
+			Master.StartLoadingMap()
 			apply_to_map()
+			Master.StopLoadingMap()
 		return 1
 	return 0
 


### PR DESCRIPTION
Использует Master.StartLoadingMap() и Master.StopLoadingMap() для приостановки загрузки подсистем во время генерации карты, что должно предотвратить ненужные обновления света и других подсистем